### PR TITLE
Preserve orderingof keys, add colorize_to_writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.6.2"
 [dependencies]
 colored = "1.6.0"
 serde = "1.0.27"
-serde_json = "1.0.9"
+serde_json = { version = "1.0.9", features = ["preserve_order"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ impl Colorizer {
     ///
     /// # Errors
     ///
-    /// An error is returned if the string is invalid JSON or an I/O error occur.s
+    /// An error is returned if the string is invalid JSON or an I/O error occurs.
     pub fn colorize_to_writer<W>(&self, s: &str, writer: &mut W) -> Result<()>
         where W: Write,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,20 @@ impl Colorizer {
         Ok(string)
     }
 
+    /// Colorize a JSON string and write the result to `writer`.
+    ///
+    /// Currently, all strings will be pretty-printed (with indentation and spacing).
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if the string is invalid JSON or an I/O error occur.s
+    pub fn colorize_to_writer<W>(&self, s: &str, writer: &mut W) -> Result<()>
+        where W: Write,
+    {
+        let value: Value = ::serde_json::from_str(s)?;
+        self.to_writer(writer, &value)
+    }
+
     fn to_vec<T: ?Sized>(&self, value: &T) -> Result<Vec<u8>>
         where T: Serialize
     {


### PR DESCRIPTION
Hi! Here's a pair of changes I made while writing a little commandline
tool using your crate. I'm trying to replace the bash alias I currently use
which is really slow because it uses Python to format the JSON and pygments
to colorize. json-color is much faster!